### PR TITLE
Relax ArgoCD repo-server probes to prevent CrashLoopBackOff

### DIFF
--- a/kubernetes/locals.tf
+++ b/kubernetes/locals.tf
@@ -5,6 +5,21 @@ locals {
         name  = "global.domain"
         value = var.argocd_domain
       },
+
+      # repo-server
+      { name = "repoServer.livenessProbe.initialDelaySeconds", value = "60" },
+      { name = "repoServer.livenessProbe.timeoutSeconds",      value = "5"  },
+      { name = "repoServer.livenessProbe.periodSeconds",       value = "20" },
+      { name = "repoServer.livenessProbe.failureThreshold",    value = "6"  },
+
+      { name = "repoServer.readinessProbe.initialDelaySeconds", value = "30" },
+      { name = "repoServer.readinessProbe.timeoutSeconds",      value = "5"  },
+      { name = "repoServer.readinessProbe.periodSeconds",       value = "10" },
+      { name = "repoServer.readinessProbe.failureThreshold",    value = "6"  },
+
+      { name = "repoServer.resources.requests.cpu",    value = "100m" },
+      { name = "repoServer.resources.requests.memory", value = "256Mi" },
+      { name = "repoServer.resources.limits.memory",   value = "512Mi" },
     ],
     var.argocd_server_insecure ? [
       {
@@ -24,3 +39,4 @@ locals {
     ] : []
   )
 }
+


### PR DESCRIPTION
Relax ArgoCD repo-server probes to avoid CrashLoopBackOff

Fixes #15

Observed with Talos Linux + Cilium, where the repo-server exits cleanly
but fails aggressive liveness checks on port 8084. This PR relaxes
the liveness and readiness probe timings and adds minimal resource requests
to keep the repo-server stable.
